### PR TITLE
Remove deprecated use of `ModelFilter`

### DIFF
--- a/deployment/transformers/utils/update_tiny_models.py
+++ b/deployment/transformers/utils/update_tiny_models.py
@@ -29,7 +29,7 @@ import os
 import time
 
 from create_dummy_models import COMPOSITE_MODELS, create_tiny_models
-from huggingface_hub import ModelFilter, hf_api
+from huggingface_hub import hf_api
 
 import transformers
 from transformers import AutoFeatureExtractor, AutoImageProcessor, AutoTokenizer
@@ -89,9 +89,7 @@ def get_tiny_model_summary_from_hub(output_path):
     # All tiny model base names on Hub
     model_names = get_all_model_names()
     models = hf_api.list_models(
-        filter=ModelFilter(
-            author="hf-internal-testing",
-        )
+        author="hf-internal-testing",
     )
     _models = set()
     for x in models:

--- a/gradients/utils/update_tiny_models.py
+++ b/gradients/utils/update_tiny_models.py
@@ -29,7 +29,7 @@ import os
 import time
 
 from create_dummy_models import COMPOSITE_MODELS, create_tiny_models
-from huggingface_hub import ModelFilter, hf_api
+from huggingface_hub import hf_api
 
 import transformers
 from transformers import AutoFeatureExtractor, AutoImageProcessor, AutoTokenizer
@@ -89,9 +89,7 @@ def get_tiny_model_summary_from_hub(output_path):
     # All tiny model base names on Hub
     model_names = get_all_model_names()
     models = hf_api.list_models(
-        filter=ModelFilter(
-            author="hf-internal-testing",
-        )
+        author="hf-internal-testing",
     )
     _models = set()
     for x in models:

--- a/quant/dbrx/utils/update_tiny_models.py
+++ b/quant/dbrx/utils/update_tiny_models.py
@@ -29,7 +29,7 @@ import os
 import time
 
 from create_dummy_models import COMPOSITE_MODELS, create_tiny_models
-from huggingface_hub import ModelFilter, hf_api
+from huggingface_hub import hf_api
 
 import transformers
 from transformers import AutoFeatureExtractor, AutoImageProcessor, AutoTokenizer
@@ -89,9 +89,7 @@ def get_tiny_model_summary_from_hub(output_path):
     # All tiny model base names on Hub
     model_names = get_all_model_names()
     models = hf_api.list_models(
-        filter=ModelFilter(
-            author="hf-internal-testing",
-        )
+        author="hf-internal-testing",
     )
     _models = set()
     for x in models:


### PR DESCRIPTION
This PR remove deprecated use of `ModelFilter`. Arguments can now be passed to `list_models` directly. See https://github.com/huggingface/huggingface_hub/issues/2028 for more details.